### PR TITLE
Feature: 공간, 물품 대여 화면 라우팅 경로 재설정

### DIFF
--- a/lib/config/router.dart
+++ b/lib/config/router.dart
@@ -14,7 +14,7 @@ final GlobalKey<NavigatorState> _rootNavigatorKey = GlobalKey<NavigatorState>();
 
 final GoRouter router = GoRouter(
   navigatorKey: _rootNavigatorKey,
-  initialLocation: '/login',
+  initialLocation: '/home',
   routes: [
     GoRoute(
       name: 'organ-auth',

--- a/lib/core/storage/token_storage.dart
+++ b/lib/core/storage/token_storage.dart
@@ -55,7 +55,7 @@ class TokenStorage {
 
   Future<String?> getDeviceRefreshToken() => storage.read(key: 'deviceAccessToken');
 
-  Future<String?> getUserAccessToken() => storage.read(key: 'userAcessToken');
+  Future<String?> getUserAccessToken() => storage.read(key: 'userAccessToken');
 
   Future<String?> getUserRefreshToken() => storage.read(key: 'userRefreshToken');
 }

--- a/lib/view/item_rental/screen/item_rental_screen.dart
+++ b/lib/view/item_rental/screen/item_rental_screen.dart
@@ -1,8 +1,8 @@
+import 'dart:developer';
+
 import 'package:danuri_flutter/core/design_system/color.dart';
 import 'package:danuri_flutter/core/design_system/text.dart';
-import 'package:danuri_flutter/core/provider/space_id_provider.dart';
 import 'package:danuri_flutter/data/view_models/item_rental_view_model.dart';
-import 'package:danuri_flutter/data/view_models/register_used_space_view_model.dart';
 import 'package:danuri_flutter/view/components/availability_sign.dart';
 import 'package:danuri_flutter/view/components/button/next_button.dart';
 import 'package:danuri_flutter/view/components/custom_top_bar.dart';
@@ -10,7 +10,6 @@ import 'package:danuri_flutter/view/components/selection_box.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:go_router/go_router.dart';
-import 'package:provider/provider.dart';
 
 class ItemRentalScreen extends StatefulWidget {
   const ItemRentalScreen({super.key});
@@ -23,8 +22,6 @@ class _ItemRentalScreenState extends State<ItemRentalScreen> {
   Map<String, String?> selectedItem = {'itemId': null};
 
   final ItemRentalViewModel _itemViewModel = ItemRentalViewModel();
-  final RegisterUsedSpaceViewModel _spaceViewModel =
-      RegisterUsedSpaceViewModel();
 
   Future<void> fetchData() async {
     await Future.wait([
@@ -32,7 +29,8 @@ class _ItemRentalScreenState extends State<ItemRentalScreen> {
       _itemViewModel.getUsageSpace(), // 공간 사용 조회
     ]).then(
       (_) => setState(
-        () {},
+        () {
+        },
       ),
     );
   }
@@ -126,14 +124,17 @@ class _ItemRentalScreenState extends State<ItemRentalScreen> {
                   centerText: '다음',
                   onTap: () async {
                     if (_itemViewModel.spaceUsage != null) {
-                      await _itemViewModel.itemRental(
-                          _itemViewModel.spaceUsage!.spaceUsageInfo.usageId,
-                          selectedItem['itemId']!,
-                          1);
+                      await _itemViewModel
+                          .itemRental(
+                              _itemViewModel.spaceUsage!.spaceUsageInfo.usageId,
+                              selectedItem['itemId']!,
+                              1)
+                          .then(
+                        (value) {
+                          if (context.mounted) context.go('/home');
+                        },
+                      );
                     }
-                    await _spaceViewModel.registerUsedSpace(
-                        context.watch<SpaceIdProvider>().spaceId);
-                    context.go('/home');
                   },
                 ),
               ],

--- a/lib/view/register_used_space/screen/register_used_space.dart
+++ b/lib/view/register_used_space/screen/register_used_space.dart
@@ -114,11 +114,20 @@ class _RegisterUsedSpaceState extends State<RegisterUsedSpace> {
               children: [
                 NextButton(
                   centerText: '다음',
-                  onTap: () {
+                  onTap: () async {
                     context
                         .read<SpaceIdProvider>()
                         .setSpaceId(selectedSpace['spaceId']!);
-                    context.push('/item-rental');
+                    await _viewModel
+                        .registerUsedSpace(
+                            context.read<SpaceIdProvider>().spaceId)
+                        .then(
+                      (_) {
+                        if (_viewModel.error == false) {
+                          if (context.mounted) context.push('/login');
+                        }
+                      },
+                    );
                   },
                 ),
               ],


### PR DESCRIPTION
# 배경 및 개요
- 공간 대여 화면에서 다음 버튼 클릭시 로그인 화면으로 라우팅 되어있지 않음
- 공간 선택-> 물품 선택 -> 공간, 물품 대여 api호출 프로세스로 되어 있던 부분을 분리하고자 합니다.  

# 작업 내용
- 라우팅 경로 수정
- 공간 대여 api호출 시점 수정

# 관련 이슈
#27 