### PR TITLE
🐛 :: (#44) 레이아웃 단계 에러 

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -47,42 +47,38 @@ class MyApp extends StatelessWidget {
     return ScreenUtilInit(
       designSize: const Size(1280, 800),
       builder: (context, child) {
-        return MediaQuery(
-          data: MediaQuery.of(context)
-              .copyWith(textScaler: TextScaler.linear(1.0)),
-          child: MultiProvider(
-            providers: [
-              ChangeNotifierProvider(
-                create: (context) => PhoneNumberProvider(),
-              ),
-              ChangeNotifierProvider(
-                create: (context) => SpaceIdProvider(),
-              ),
-              ChangeNotifierProvider(
-                create: (context) => ItemIdProvider(),
-              ),
-              ChangeNotifierProvider(
-                create: (context) => ExitRoomFlowProvider(),
-              ),
-              ChangeNotifierProvider(
-                create: (context) => RegisterUsedSpaceFlowProvider(),
-              ),
-              ChangeNotifierProvider(
-                create: (context) => ItemRentalFlowProvider(),
-              ),
-              ChangeNotifierProvider(
-                create: (context) => RentalIdProvider(),
-              ),
-            ],
-            child: MaterialApp.router(
-              debugShowCheckedModeBanner: false,
-              theme: ThemeData(
-                scaffoldBackgroundColor: DanuriColor.background1,
-                fontFamily: 'Pretendard',
-              ),
-              routerConfig: router(
-                firstRun ? '/organ-auth' : '/',
-              ),
+        return MultiProvider(
+          providers: [
+            ChangeNotifierProvider(
+              create: (context) => PhoneNumberProvider(),
+            ),
+            ChangeNotifierProvider(
+              create: (context) => SpaceIdProvider(),
+            ),
+            ChangeNotifierProvider(
+              create: (context) => ItemIdProvider(),
+            ),
+            ChangeNotifierProvider(
+              create: (context) => ExitRoomFlowProvider(),
+            ),
+            ChangeNotifierProvider(
+              create: (context) => RegisterUsedSpaceFlowProvider(),
+            ),
+            ChangeNotifierProvider(
+              create: (context) => ItemRentalFlowProvider(),
+            ),
+            ChangeNotifierProvider(
+              create: (context) => RentalIdProvider(),
+            ),
+          ],
+          child: MaterialApp.router(
+            debugShowCheckedModeBanner: false,
+            theme: ThemeData(
+              scaffoldBackgroundColor: DanuriColor.background1,
+              fontFamily: 'Pretendard',
+            ),
+            routerConfig: router(
+              firstRun ? '/organ-auth' : '/',
             ),
           ),
         );


### PR DESCRIPTION
# 문제점
- MediaQuery.of(context).copyWith()으로 고정되어 있어, 키보드 활성화 시 veiwInsets의 정보가 갱신되지 않아, 레이아웃 단계 에러가 발생하였고, 그로 인해 라우터가 초기 경로인 홈 화면으로 라우팅되는 트리거가 발생

# 해결 방법
- MediaQuery 위젯을 제거하여 해결했습니다.

# 관련 이슈
#44 